### PR TITLE
dshop-152 no carga los datos de doble optin

### DIFF
--- a/admin/controllers/Form_Controller.php
+++ b/admin/controllers/Form_Controller.php
@@ -103,13 +103,29 @@ class DPLR_Form_Controller
     if (isset($form_to_update) && count($form_to_update) > 0) {
       // $form_to_update["settings"]["message_success"] = 'success message hardcodeado';
 
-      DPLR_Form_Model::update($form_id, ['name'=>$form_to_update['name'], 'title' => $form_to_update['title'], 'list_id' => $form_to_update['list_id'], 'form_orientation' => $form_to_update['form_orientation'] ]);
+      DPLR_Form_Model::update($form_id, ['name'=>$form_to_update['name'], 'title' => $form_to_update['title'], 'list_id' => $form_to_update['list_id'], 'form_orientation' => $form_to_update["settings"]['form_orientation'] ]);
 
       if($form_to_update["settings"]["form_doble_optin"] === "yes"){
+
+        $form = DPLR_Form_Model::get($form_id, true);
+        $form_to_update["settings"]["form_email_confirmacion_nombre_remitente"] = $form->settings["form_email_confirmacion_nombre_remitente"];
+        $form_to_update["settings"]["form_email_confirmacion_email_remitente"] = $form->settings["form_email_confirmacion_email_remitente"];
+        $form_to_update["settings"]["form_email_confirmacion_asunto"] = $form->settings["form_email_confirmacion_asunto"];
+        $form_to_update["settings"]["form_email_confirmacion_pre_encabezado"] = $form->settings["form_email_confirmacion_pre_encabezado"];
+        $form_to_update["settings"]["form_email_reply_to"] = $form->settings["form_email_reply_to"];
+        $form_to_update["settings"]["form_name"] = $form->settings["form_name"];
+
         $form_data["fromName"] = $form_to_update["settings"]["form_email_confirmacion_nombre_remitente"];
         $form_data["fromEmail"] = $form_to_update["settings"]["form_email_confirmacion_email_remitente"];
         $form_data["subject"] = $form_to_update["settings"]["form_email_confirmacion_asunto"];
         $form_data["preheader"] = $form_to_update["settings"]["form_email_confirmacion_pre_encabezado"];
+
+        //if(isset($form["settings"]["form_email_reply_to"]) && !empty($form["settings"]["form_email_reply_to"])) {
+          $form_data["replyTo"] = $form_to_update["settings"]["form_email_reply_to"];
+        //}
+
+        $form_data["name"] = $form_to_update["settings"]["form_name"];
+
         if($form_to_update["settings"]["form_pagina_confirmacion"] == 'url'){
           $form_data["urlLanding"] = $form_to_update["settings"]["form_pagina_confirmacion_url"];
         }
@@ -118,18 +134,14 @@ class DPLR_Form_Controller
           $form_data["urlLanding"] = $landing_url;
         }
 
-        if(isset($form["settings"]["form_email_reply_to"]) && !empty($form["settings"]["form_email_reply_to"])) {
-          $form_data["replyTo"] = $form_to_update["settings"]["form_email_reply_to"];
-        }
-
-        $form_data["name"] = $form_to_update["settings"]["form_name"];
-
         $method["route"] = "DobleOptinTemplate";
         $method["httpMethod"] = "post";
         // aca creo la plantilla y la asocio a este form_id.
         // plugins/doppler-form/includes/DopplerAPIClient/DopplerService.php
         $response = $this->doppler_service->call($method, '', $form_data);
 
+        $logger = wc_get_logger();
+        $logger->info( wc_print_r( array("form" => $form_data, "response" => $response), true ), array( 'source' => 'form_update' ) );
 
         $form_data = $form_to_update["content"];
         $form_to_update["settings"]["form_email_confirmacion_email_contenido"] = $form_data; 

--- a/admin/controllers/Form_Controller.php
+++ b/admin/controllers/Form_Controller.php
@@ -119,10 +119,9 @@ class DPLR_Form_Controller
         $form_data["fromEmail"] = $form_to_update["settings"]["form_email_confirmacion_email_remitente"];
         $form_data["subject"] = $form_to_update["settings"]["form_email_confirmacion_asunto"];
         $form_data["preheader"] = $form_to_update["settings"]["form_email_confirmacion_pre_encabezado"];
-
-        //if(isset($form["settings"]["form_email_reply_to"]) && !empty($form["settings"]["form_email_reply_to"])) {
+        if(isset($form_to_update["settings"]["form_email_reply_to"]) && !empty($form_to_update["settings"]["form_email_reply_to"])) {
           $form_data["replyTo"] = $form_to_update["settings"]["form_email_reply_to"];
-        //}
+        }
 
         $form_data["name"] = $form_to_update["settings"]["form_name"];
 

--- a/admin/partials/forms-create.php
+++ b/admin/partials/forms-create.php
@@ -20,7 +20,7 @@
               <option value=""><?php _e('Select the destination List where your new Subscribers will be sent', 'doppler-form'); ?></option>
               <?php 
                 for ($i=0; $i < count($dplr_lists); $i++) { 
-                ?><option <?php echo intval($form['list_id']) == intval($dplr_lists[$i]->listId) ? 'selected="selected"' : ''; ?> value="<?php echo $dplr_lists[$i]->listId; ?>"><?php echo trim($dplr_lists[$i]->name); ?></option><?php
+                ?><option <?php echo isset($form['list_id']) && intval($form['list_id']) == intval($dplr_lists[$i]->listId) ? 'selected="selected"' : ''; ?> value="<?php echo $dplr_lists[$i]->listId; ?>"><?php echo trim($dplr_lists[$i]->name); ?></option><?php
                 }
               ?>
             </select>
@@ -99,7 +99,7 @@
           </div>
           <div class="dplr_input_section dplr_thankyou_url" <?= (isset($form['settings']['use_thankyou_page']) && $form['settings']['use_thankyou_page']==='yes')? 'style="display:block"' : 'style="display:none"'; ?>>
             <label for="submit_text"><?php _e('Custom confirmation page URL', 'doppler-form')?> <span class="hlp"><?php _e('Enter the URL of the page that you\'ve created.', 'doppler-form')?></span></label>
-            <input type="url" name="settings[thankyou_page_url]" value="<?=$form['settings']["thankyou_page_url"] ?>" pattern="https?://.+" placeholder="" maxlength="150" <?php if(isset($form['settings']['use_thankyou_page']) && $form['settings']['use_thankyou_page']==='yes') echo 'required';?>/>
+            <input type="url" name="settings[thankyou_page_url]" value="<?=isset($form['settings']["thankyou_page_url"]) ? $form['settings']["thankyou_page_url"]:'' ?>" pattern="https?://.+" placeholder="" maxlength="150" <?php if(isset($form['settings']['use_thankyou_page']) && $form['settings']['use_thankyou_page']==='yes') echo 'required';?>/>
           </div>
           <div class="dplr_input_section">
             <label for="settings[use_consent_field]"><?php _e('Consent Field (GDPR)', 'doppler-form')?> <!--<span class="hlp"><?php _e('What is it? Press','doppler-form')?> <?= '<a href="'.__('https://help.fromdoppler.com/en/general-data-protection-regulation?utm_source=landing&utm_medium=integracion&utm_campaign=wordpress', 'doppler-form').'" target="blank">'.__('HELP','doppler-form').'</a>'?>.</span>--></label>


### PR DESCRIPTION
El error de daba por enviar los inputs disabled, entonces lo que se hizo fue consultar los datos que están en la base de datos y setear los valores.
También se agregaron un par de validaciones mas en el formulario de edición (isset). Y de paso se agregó un log para ver que devuelve el servicio de edición.
Y por último, había un bug con respecto al campo orientación, se estaba consultando mal.