### PR TITLE
dshop-156 remove padding

### DIFF
--- a/admin/css/doppler-form-admin.css
+++ b/admin/css/doppler-form-admin.css
@@ -476,10 +476,6 @@
   display: block !important;
 }
 
-.dplr_settings form #section_email_confirmacion h2, .dplr_settings form #section_email_confirmacion p {
-  padding-left: 10px;
-}
-
 .dplr_settings form #error-message {
   display: none;
   padding: 10px 20px;


### PR DESCRIPTION
Se quitó del css la padding de H2 para que quede alineado con los demás textos