### PR TITLE
Dshop 161

### DIFF
--- a/admin/controllers/Form_Controller.php
+++ b/admin/controllers/Form_Controller.php
@@ -42,6 +42,7 @@ class DPLR_Form_Controller
         $form["content"] = str_replace('href=\"[[[ConfirmationLink]]]\"', "href=[[[ConfirmationLink]]]", $form["content"]);
         $form["content"] = str_replace('href="[[[ConfirmationLink]]]"', "href=[[[ConfirmationLink]]]", $form["content"]);
         $form["content"] = str_replace('href="http://[[[ConfirmationLink]]]"', "href=[[[ConfirmationLink]]]", $form["content"]);
+        $form["content"] = str_replace('href="\"http://[[[ConfirmationLink]]]\""', "href=[[[ConfirmationLink]]]", $form["content"]);
 
         $method["route"] = "DobleOptinTemplate";
         $method["httpMethod"] = "post";
@@ -154,6 +155,7 @@ class DPLR_Form_Controller
         $form_to_update["content"] = str_replace('href=\"[[[ConfirmationLink]]]\"', "href=[[[ConfirmationLink]]]", $form_to_update["content"]);
         $form_to_update["content"] = str_replace('href="[[[ConfirmationLink]]]"', "href=[[[ConfirmationLink]]]", $form_to_update["content"]);
         $form_to_update["content"] = str_replace('href="http://[[[ConfirmationLink]]]"', "href=[[[ConfirmationLink]]]", $form_to_update["content"]);
+        $form["content"] = str_replace('href="\"http://[[[ConfirmationLink]]]\""', "href=[[[ConfirmationLink]]]", $form["content"]);
 
         $form_data = $form_to_update["content"];
         $form_to_update["settings"]["form_email_confirmacion_email_contenido"] = $form_data; 

--- a/admin/controllers/Form_Controller.php
+++ b/admin/controllers/Form_Controller.php
@@ -43,6 +43,7 @@ class DPLR_Form_Controller
         $form["content"] = str_replace('href="[[[ConfirmationLink]]]"', "href=[[[ConfirmationLink]]]", $form["content"]);
         $form["content"] = str_replace('href="http://[[[ConfirmationLink]]]"', "href=[[[ConfirmationLink]]]", $form["content"]);
         $form["content"] = str_replace('href="\"http://[[[ConfirmationLink]]]\""', "href=[[[ConfirmationLink]]]", $form["content"]);
+        $form["content"] = str_replace('href=\"http://[[[ConfirmationLink]]]\"', "href=[[[ConfirmationLink]]]", $form["content"]);
 
         $method["route"] = "DobleOptinTemplate";
         $method["httpMethod"] = "post";
@@ -156,6 +157,7 @@ class DPLR_Form_Controller
         $form_to_update["content"] = str_replace('href="[[[ConfirmationLink]]]"', "href=[[[ConfirmationLink]]]", $form_to_update["content"]);
         $form_to_update["content"] = str_replace('href="http://[[[ConfirmationLink]]]"', "href=[[[ConfirmationLink]]]", $form_to_update["content"]);
         $form_to_update["content"] = str_replace('href="\"http://[[[ConfirmationLink]]]\""', "href=[[[ConfirmationLink]]]", $form_to_update["content"]);
+        $form_to_update["content"] = str_replace('href=\"http://[[[ConfirmationLink]]]\"', "href=[[[ConfirmationLink]]]", $form_to_update["content"]);
 
         $form_data = $form_to_update["content"];
         $form_to_update["settings"]["form_email_confirmacion_email_contenido"] = $form_data; 

--- a/admin/controllers/Form_Controller.php
+++ b/admin/controllers/Form_Controller.php
@@ -41,6 +41,7 @@ class DPLR_Form_Controller
 
         $form["content"] = str_replace('href=\"[[[ConfirmationLink]]]\"', "href=[[[ConfirmationLink]]]", $form["content"]);
         $form["content"] = str_replace('href="[[[ConfirmationLink]]]"', "href=[[[ConfirmationLink]]]", $form["content"]);
+        $form["content"] = str_replace('href="http://[[[ConfirmationLink]]]"', "href=[[[ConfirmationLink]]]", $form["content"]);
 
         $method["route"] = "DobleOptinTemplate";
         $method["httpMethod"] = "post";
@@ -152,6 +153,7 @@ class DPLR_Form_Controller
 
         $form_to_update["content"] = str_replace('href=\"[[[ConfirmationLink]]]\"', "href=[[[ConfirmationLink]]]", $form_to_update["content"]);
         $form_to_update["content"] = str_replace('href="[[[ConfirmationLink]]]"', "href=[[[ConfirmationLink]]]", $form_to_update["content"]);
+        $form_to_update["content"] = str_replace('href="http://[[[ConfirmationLink]]]"', "href=[[[ConfirmationLink]]]", $form_to_update["content"]);
 
         $form_data = $form_to_update["content"];
         $form_to_update["settings"]["form_email_confirmacion_email_contenido"] = $form_data; 

--- a/admin/controllers/Form_Controller.php
+++ b/admin/controllers/Form_Controller.php
@@ -155,7 +155,7 @@ class DPLR_Form_Controller
         $form_to_update["content"] = str_replace('href=\"[[[ConfirmationLink]]]\"', "href=[[[ConfirmationLink]]]", $form_to_update["content"]);
         $form_to_update["content"] = str_replace('href="[[[ConfirmationLink]]]"', "href=[[[ConfirmationLink]]]", $form_to_update["content"]);
         $form_to_update["content"] = str_replace('href="http://[[[ConfirmationLink]]]"', "href=[[[ConfirmationLink]]]", $form_to_update["content"]);
-        $form["content"] = str_replace('href="\"http://[[[ConfirmationLink]]]\""', "href=[[[ConfirmationLink]]]", $form["content"]);
+        $form_to_update["content"] = str_replace('href="\"http://[[[ConfirmationLink]]]\""', "href=[[[ConfirmationLink]]]", $form_to_update["content"]);
 
         $form_data = $form_to_update["content"];
         $form_to_update["settings"]["form_email_confirmacion_email_contenido"] = $form_data; 

--- a/admin/js/doppler-form-admin.js
+++ b/admin/js/doppler-form-admin.js
@@ -506,12 +506,19 @@ function generateErrorMsg(body){
 
 function validateEmailContent(e){
 
-  var content = tinyMCE.activeEditor.getContent();
+  var content = '';
+  if(typeof tinyMCE != 'undefined') {
+  	content = tinyMCE.activeEditor.getContent();
+  } else {
+  	content = document.getElementById("content_ifr").contentDocument.body.innerHTML || document.getElementById("content_ifr").contentWindow.document.body.innerHTML;
+  }
 
   content = content.replace('href="[[[ConfirmationLink]]]"', "href=[[[ConfirmationLink]]]");
   content = content.replace('href="http://[[[ConfirmationLink]]]"', "href=[[[ConfirmationLink]]]");
 
-  tinyMCE.activeEditor.setContent(content);
+  if(typeof tinyMCE != 'undefined') {
+  	tinyMCE.activeEditor.setContent(content);
+  }
 
   if(document.getElementById("settings[form_doble_optin]").value === 'yes'){
     if(

--- a/admin/js/doppler-form-admin.js
+++ b/admin/js/doppler-form-admin.js
@@ -507,17 +507,22 @@ function generateErrorMsg(body){
 function validateEmailContent(e){
 
   var content = '';
-  if(typeof tinyMCE != 'undefined') {
-  	content = tinyMCE.activeEditor.getContent();
+
+  if(!tinyMCE.activeEditor) jQuery('.wp-editor-wrap .switch-tmce').trigger('click');
+
+  if(!tinyMCE.activeEditor) {
+  	content = document.getElementById('content').value;
   } else {
-  	content = document.getElementById("content_ifr").contentDocument.body.innerHTML || document.getElementById("content_ifr").contentWindow.document.body.innerHTML;
+  	content = tinyMCE.activeEditor.getContent();
   }
 
   content = content.replace('href="[[[ConfirmationLink]]]"', "href=[[[ConfirmationLink]]]");
   content = content.replace('href="http://[[[ConfirmationLink]]]"', "href=[[[ConfirmationLink]]]");
 
-  if(typeof tinyMCE != 'undefined') {
+  if(!tinyMCE.activeEditor) {
   	tinyMCE.activeEditor.setContent(content);
+  } else {
+  	document.getElementById('content').value = content;
   }
 
   if(document.getElementById("settings[form_doble_optin]").value === 'yes'){
@@ -554,9 +559,20 @@ function hideShowConfigLandingOrURL(){
 
 // remove quote marks from ConfirmationLink href.
 function removeQuoteMarksFromConfirmationLink(){
-  var content = tinyMCE.activeEditor.getContent();
-  if(content.includes("href=\"[[[ConfirmationLink]]]\"")){
-  	content = content.replace("href=\"[[[ConfirmationLink]]]\"", "href=[[[ConfirmationLink]]]");
-    tinyMCE.activeEditor.setContent(content);
+
+  if(!tinyMCE.activeEditor) jQuery('.wp-editor-wrap .switch-tmce').trigger('click');
+
+  if(!tinyMCE.activeEditor) {
+  	var content = document.getElementById('content').value;
+  	if(content.includes("href=\"[[[ConfirmationLink]]]\"")){
+		content = content.replace("href=\"[[[ConfirmationLink]]]\"", "href=[[[ConfirmationLink]]]");
+		document.getElementById('content').value = content;
+	}
+  } else {
+	var content = tinyMCE.activeEditor.getContent();
+	if(content.includes("href=\"[[[ConfirmationLink]]]\"")){
+		content = content.replace("href=\"[[[ConfirmationLink]]]\"", "href=[[[ConfirmationLink]]]");
+		tinyMCE.activeEditor.setContent(content);
+	}
   }
 }


### PR DESCRIPTION
El problema esta en que el objeto activeEditor de tinyMCE es undefined, y cuando da error no valida, esto no pasa para todos los casos solo se pudo probar en la maquina de Fernando lo que hizo difícil ver puntualmente el problema. Lo que se hizo fue agregar una validación para ver si activeEditor es undefined y si es asi, aplicar un fix para levantar el contenido del editor directamente desde el textarea.